### PR TITLE
use 2nd core from Pico for custom device

### DIFF
--- a/AltimeterAerosonic/AltimeterAerosonic_platformio.ini
+++ b/AltimeterAerosonic/AltimeterAerosonic_platformio.ini
@@ -15,7 +15,7 @@ build_src_filter =
 lib_deps = 
   SPI
   olikraus/U8g2
-custom_core_firmware_version = 2.5.1								; define the version from the core firmware files your build should base on
+custom_core_firmware_version = use_2nd_core								; define the version from the core firmware files your build should base on
 custom_device_folder = AltimeterAerosonic										; path to your Custom Device Sources, replace "Template" by your folder name
 custom_community_project = Altimeter Aerosonic								; Should match "Project" from section "Community" within the board.json file, it's the name of the ZIP file
 
@@ -61,6 +61,7 @@ build_flags =
 	-I./src/_Boards/RaspberryPi/Pico								; Include the required board definition. If you need your own definition, adapt this to your path (e.g. -I./CustomDevices/_template/_Boards)
 	'-DMOBIFLIGHT_TYPE="Altimeter Aerosonic RaspiPico"'				; this must match with "MobiFlightType" within the .json file
 	'-DMOBIFLIGHT_NAME="Altimeter Aerosonic"'						; this will show up as Name in the settings dialog unless it gets change from there
+	-DUSE_2ND_CORE
 build_src_filter =
 	${env.build_src_filter}											; don't change this one!
 	${env_template.build_src_filter}								; don't change this one!

--- a/AltimeterAerosonic/AltimeterAerosonic_platformio.ini
+++ b/AltimeterAerosonic/AltimeterAerosonic_platformio.ini
@@ -61,7 +61,8 @@ build_flags =
 	-I./src/_Boards/RaspberryPi/Pico								; Include the required board definition. If you need your own definition, adapt this to your path (e.g. -I./CustomDevices/_template/_Boards)
 	'-DMOBIFLIGHT_TYPE="Altimeter Aerosonic RaspiPico"'				; this must match with "MobiFlightType" within the .json file
 	'-DMOBIFLIGHT_NAME="Altimeter Aerosonic"'						; this will show up as Name in the settings dialog unless it gets change from there
-	-DUSE_2ND_CORE
+	;-DUSE_2ND_CORE													; uncomment this to run custom device on 2nd core, NOT at the same time with STEPPER_ON_2ND_CORE
+	-DSTEPPER_ON_2ND_CORE											; uncomment this to run stepper on 2nd core, NOT at the same time with USE_2ND_CORE
 build_src_filter =
 	${env.build_src_filter}											; don't change this one!
 	${env_template.build_src_filter}								; don't change this one!

--- a/get_CoreFiles.py
+++ b/get_CoreFiles.py
@@ -8,7 +8,7 @@ print("Compiling for Core Version: " + CORESOURCE_TAG)
 
 if not os.path.exists(CORESOURCE_DIR):
     print ("Cloning Mobiflight-CustomDevices repo ... ")
-    env.Execute(f"git clone --depth 1 --filter=blob:none --sparse --branch {CORESOURCE_TAG} https://github.com/MobiFlight/MobiFlight-FirmwareSource $PROJECT_DIR/src")
+    env.Execute(f"git clone --depth 1 --filter=blob:none --sparse --branch {CORESOURCE_TAG} https://github.com/elral/MobiFlight-FirmwareSource $PROJECT_DIR/src")
     env.Execute(f"git --work-tree=$PROJECT_DIR/src --git-dir=$PROJECT_DIR/src/.git sparse-checkout set _Boards src")
     if os.path.isfile(CORESOURCE_DIR + "/platformio.ini"):
         os.remove(CORESOURCE_DIR + "/platformio.ini")


### PR DESCRIPTION
## Description of changes

Code changes to run a custom device on 2nd core from Raspberry Pico.

**CAUTION!**
Before using this branch the folder `/src` has to be deleted. Otherwise the new branch will not be found.
The new branch is within my fork of the Firmware Repo